### PR TITLE
Fix READMEs documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,18 @@ npm i --save @ionos-cloud/sdk-nodejs
 ## Usage
 Import the SDK using:
 
-```const sdk = require('@ionos-cloud/sdk-nodejs')```
+```javascript 
+const sdk = require('@ionos-cloud/sdk-nodejs')
+```
 
 Or, if the import is done from an ES module, use:
 
-```import * as sdk from '@ionos-cloud/sdk-nodejs';```
+```javascript
+import * as sdk from '@ionos-cloud/sdk-nodejs';
+```
 
 Usage example:
-```javscript
+```javascript
 const config = new sdk.Configuration({username: 'YOUR_USERNAME', password: 'YOUR_PASSWORD'});
 const dcApi = new sdk.DataCentersApi(config);
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,14 +23,18 @@ npm i --save @ionos-cloud/sdk-nodejs
 ## Usage
 Import the SDK using:
 
-```const sdk = require('@ionos-cloud/sdk-nodejs')```
+```javascript
+const sdk = require('@ionos-cloud/sdk-nodejs')
+```
 
 Or, if the import is done from an ES module, use:
 
-```import * as sdk from '@ionos-cloud/sdk-nodejs';```
+```javascript
+import * as sdk from '@ionos-cloud/sdk-nodejs';
+```
 
 Usage example:
-```text
+```javascript
 const config = new sdk.Configuration({username: 'YOUR_USERNAME', password: 'YOUR_PASSWORD'});
 const dcApi = new sdk.DataCentersApi(config);
 


### PR DESCRIPTION
Solves https://github.com/ionos-cloud/sdk-nodejs/pull/7#discussion_r982715801.

I also added the `javascript` keyword for every defined example in the **README** because it highlights the text in a nice manner. 